### PR TITLE
Tds2Emailを追加

### DIFF
--- a/lib/gmo/const.rb
+++ b/lib/gmo/const.rb
@@ -125,6 +125,7 @@ module GMO
       :tax                   => "Tax",
       :td_flag               => "TdFlag",
       :td_tenant_name        => "TdTenantName",
+      :tds2_email            => "Tds2Email",
       :tel_no                => "TelNo",
       :token                 => "Token",
       :token_seq             => "TokenSeq",


### PR DESCRIPTION
## Issue
[#10929 ](https://github.com/pocket-marche/pocket_marche/issues/10929)

## 変更の詳細
https://github.com/pocket-marche/pocket_marche/issues/10929#issuecomment-2179863865

gem側からtds2_emailを送信出来るようにする
## その他

